### PR TITLE
Fixed byte vs string issues in auth, regex edit in auth test

### DIFF
--- a/volttron/platform/auth.py
+++ b/volttron/platform/auth.py
@@ -140,7 +140,7 @@ class AuthService(Agent):
             with open(self._protected_topics_file) as fil:
                 # Use gevent FileObject to avoid blocking the thread
                 data = FileObject(fil, close=False).read()
-                self._protected_topics = jsonapi.loads(data) if data else {}
+                self._protected_topics = jsonapi.loadb(data) if data else {}
                 self._send_protected_update_to_pubsub(self._protected_topics)
         except Exception:
             _log.exception('error loading %s', self._protected_topics_file)
@@ -171,7 +171,7 @@ class AuthService(Agent):
         if self._is_connected:
             try:
                 # <recipient, subsystem, args, msg_id, flags>
-                self.core.socket.send_vip(b'', 'pubsub', frames, copy=False)
+                self.core.socket.send_vip(b'', b'pubsub', frames, copy=False)
             except VIPError as ex:
                 _log.error("Error in sending protected topics update to clear PubSub: " + str(ex))
 

--- a/volttron/platform/keystore.py
+++ b/volttron/platform/keystore.py
@@ -128,14 +128,14 @@ class KeyStore(BaseJSONStore):
         """Get key and make sure it's type is str (not unicode)
 
         The json module returns all strings as unicode type, but base64
-        decode expects str type as input. The conversion from unicode
+        decode expects byte type as input. The conversion from unicode
         type to str type is safe in this case, because encode_key
         returns str type (ASCII characters only).
         """
         key = self.load().get(keyname, None)
         if key:
             try:
-                key = str(key)
+                key.encode('ascii')
             except UnicodeEncodeError:
                 _log.warning(
                     'Non-ASCII character found for key {} in {}'

--- a/volttron/platform/vip/keydiscovery.py
+++ b/volttron/platform/vip/keydiscovery.py
@@ -198,7 +198,7 @@ class KeyDiscoveryAgent(Agent):
 
         frames = [op, address]
         try:
-            self._vip_socket.send_vip(b'', 'routing_table', frames, copy=False)
+            self._vip_socket.send_vip(b'', b'routing_table', frames, copy=False)
         except ZMQError as ex:
             # Try sending later
             _log.error("ZMQ error while sending external platform info to router: {}".format(ex))

--- a/volttrontesting/platform/auth_test.py
+++ b/volttrontesting/platform/auth_test.py
@@ -222,10 +222,10 @@ def test_pubsub_authorized_regex1(volttron_instance_encrypt):
 @pytest.mark.auth
 def test_pubsub_unauthorized_regex2(volttron_instance_encrypt):
     pubsub_unauthorized(volttron_instance_encrypt,
-                        topic='foo/bar', regex='/foo\/.*/')
+                        topic='foo/bar', regex=r'/foo\/.*/')
 
 
 @pytest.mark.auth
 def test_pubsub_authorized_regex2(volttron_instance_encrypt):
     pubsub_authorized(volttron_instance_encrypt,
-                      topic='foo/bar', regex='/foo\/.*/')
+                      topic='foo/bar', regex=r'/foo\/.*/')

--- a/volttrontesting/utils/platformwrapper.py
+++ b/volttrontesting/utils/platformwrapper.py
@@ -338,7 +338,7 @@ class PlatformWrapper:
         auth_path = os.path.join(self.volttron_home, 'auth.json')
         try:
             with open(auth_path, 'r') as fd:
-                data = strip_comments(FileObject(fd, close=False).read())
+                data = strip_comments(FileObject(fd, close=False).read().decode('utf-8'))
                 if data:
                     auth = jsonapi.loads(data)
                 else:


### PR DESCRIPTION
# Description

Fixed regex warning in auth by adding `r` in front of a regex string. Fixed issue in auth where it was trying to send a string but needed to send bytes. Fixed issue in platformwrapper where it was reading bytes from the auth file json but needed to read a string (decoded to utf-8)

Fixes # (issue)

## Type of change

2to3 fixes; mostly bytes vs strings

# How Has This Been Tested?

Made sure all auth pytests pass and no errors or warnings are generated