### PR TITLE
Python3

### DIFF
--- a/volttron/platform/vip/agent/subsystems/web.py
+++ b/volttron/platform/vip/agent/subsystems/web.py
@@ -62,15 +62,17 @@ class WebSubSystem(SubsystemBase):
         self._endpoints = {}
         self._ws_endpoint = {}
 
-        rpc.export(self._opened, 'client.opened')
-        rpc.export(self._closed, 'client.closed')
-        rpc.export(self._message, 'client.message')
-        rpc.export(self._route_callback, 'route.callback')
+        def onsetup(sender, **kqargs):
+            rpc.export(self._opened, 'client.opened')
+            rpc.export(self._closed, 'client.closed')
+            rpc.export(self._message, 'client.message')
+            rpc.export(self._route_callback, 'route.callback')
 
         def onstop(sender, **kwargs):
             rpc.call(MASTER_WEB, 'unregister_all_agent_routes')
 
         core.onstop.connect(onstop, self)
+        core.onsetup.connect(onsetup, self)
 
     def unregister_all_routes(self):
         self._rpc().call(MASTER_WEB, 'unregister_all_agent_routes')

--- a/volttron/platform/web.py
+++ b/volttron/platform/web.py
@@ -622,7 +622,7 @@ class MasterWebService(Agent):
             ))
             try:
                 res = self.vip.rpc.call(peer, 'route.callback',
-                                        passenv, data).get(timeout=60)
+                                        passenv, data.decode('ascii')).get(timeout=60)
             except:
                 _log.exception(f"Error running agent callback {peer}:")
                 raise

--- a/volttrontesting/platform/test_platform_web.py
+++ b/volttrontesting/platform/test_platform_web.py
@@ -125,7 +125,7 @@ class WebAgent(Agent):
         self.vip.web.register_path("/web", WEBROOT)
 
     def text(self, env, data):
-        ret = "200 OK", base64.b64encode("This is some text").decode("ascii"), [
+        ret = "200 OK", base64.b64encode(b"This is some text").decode("ascii"), [
         ('Content-Type', 'text/plain')]
         _log.debug('returning: {}'.format(ret))
         return ret


### PR DESCRIPTION
# Description

In `app_routing()` in platform/web.py, `data` is a byte string. It must be sent to the message buss as a unicode string, so we must decode it into ascii before sending. It must be decoded into the original binary data on the receiving end. I was getting an error in `text()` in the webagent (test_platform_web.py) that base64.b64decode was expecting a byte string, so I added a 'b' before the string. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All the pytests in test_platform_web.py pass now (except one which is ignored)
